### PR TITLE
bugfix: correctly identify find variant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Define scripts to work with
 SCRIPTS=("wtadd.sh" "wtremove.sh" "wtclone.sh" "wtlist.sh")
 


### PR DESCRIPTION
When MacOS, using `uname` to identify the find variant might produce false positives.  This PR updates the functionality with a detection function.

Fixes: #4 